### PR TITLE
Add context to title string

### DIFF
--- a/includes/admin/class-tplc-admin-menus.php
+++ b/includes/admin/class-tplc-admin-menus.php
@@ -27,7 +27,7 @@ class TPLC_Admin_Menus {
 	 * Add menu item
 	 */
 	public function status_menu() {
-		add_submenu_page( 'tools.php',  __( 'Child Theme Check', 'child-theme-check' ), __( 'Child Theme Check', 'child-theme-check' ), 'manage_options', 'tplc-status', array( $this, 'status_page' ) );
+		add_submenu_page( 'tools.php',  _x( 'Child Theme Check', 'Page and Menu Title', 'child-theme-check' ), _x( 'Child Theme Check', 'Page and Menu Title', 'child-theme-check' ), 'manage_options', 'tplc-status', array( $this, 'status_page' ) );
 	}
 
 	/**

--- a/includes/admin/views/html-admin-page-status-diff.php
+++ b/includes/admin/views/html-admin-page-status-diff.php
@@ -96,7 +96,7 @@ jQuery( function($) {
 						);
 						
 						printf(
-							'<div class="diff-wrapper"><table class="diff"><tr><th class="diffheader">%s:' . $template . '</th><th>&#160;</th><th class="diffheader">%s:' . $theme . '</th></tr></table>%s</div>',
+							'<div class="diff-wrapper"><table class="diff"><tr><th class="diffheader">%s: ' . $template . '</th><th>&#160;</th><th class="diffheader">%s: ' . $theme . '</th></tr></table>%s</div>',
 							__( 'Parent Theme', 'child-theme-check'),
 							__( 'Child Theme', 'child-theme-check'),
 							$diff_table

--- a/includes/admin/views/html-admin-page-status.php
+++ b/includes/admin/views/html-admin-page-status.php
@@ -1,5 +1,5 @@
 <div class="wrap">
-	<h1><?php _e( 'Child Theme Check', 'child-theme-check' ); ?></h1>
+	<h1><?php _ex( 'Child Theme Check', 'Page and Menu Title', 'child-theme-check' ); ?></h1>
 
 <?php if ( ! is_child_theme() ) { ?>
 

--- a/includes/admin/views/html-notice-template-check.php
+++ b/includes/admin/views/html-notice-template-check.php
@@ -10,5 +10,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <div id="message" class="updated">
 	<p><?php _e( '<strong>The active child theme\'s parent has been updated and the child theme might have outdated copies of parent theme files</strong> &#8211; please ensure you update them manually. See the child theme check for more details.', 'child-theme-check' ); ?></p>
-	<p class="submit"><a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=tplc-status' ) ); ?>"><?php _e( 'Child Theme Check', 'child-theme-check' ); ?></a> <a class="skip button-primary" href="<?php echo esc_url( add_query_arg( 'hide_template_files_notice', 'template_files' ) ); ?>"><?php _e( 'Hide this notice', 'child-theme-check' ); ?></a></p>
+	<p class="submit"><a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=tplc-status' ) ); ?>"><?php _ex( 'Child Theme Check', 'Page and Menu Title', 'child-theme-check' ); ?></a> <a class="skip button-primary" href="<?php echo esc_url( add_query_arg( 'hide_template_files_notice', 'template_files' ) ); ?>"><?php _e( 'Hide this notice', 'child-theme-check' ); ?></a></p>
 </div>


### PR DESCRIPTION
This allows translation of the verb (button label), page and menu titles, without the need to translate the plugin name itself, that should be kept untranslated.

Also added a single space between "Parent/Child Theme:" and the filename itself to improve readability.